### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         <h2>Kinto — Store, Sync, Share, and Self-Host</h2>
         <br>
         <div class="cta-btn">
-          <a href="http://kinto.readthedocs.io/en/stable/tutorials/install.html" class="btn">Get started</a>
+          <a href="https://kinto.readthedocs.io/en/stable/tutorials/install.html" class="btn">Get started</a>
         </div>
       </div>
     </div>
@@ -137,7 +137,7 @@ tasks
       <div class="col-md-4" id="text-kintojs">
         <article>
           <h2>Ready for the browser</h2>
-          <p><a href="http://kintojs.readthedocs.org/">Kinto.js</a> helps you to build Web Apps that syncs.</p>
+          <p><a href="https://kintojs.readthedocs.io/">Kinto.js</a> helps you to build Web Apps that syncs.</p>
           <ul>
             <li><a href="http://offlinefirst.org/">Offline first</a></li>
             <li>In-browser storage using IndexedDB</li>
@@ -190,7 +190,7 @@ tasks
     </header>
     <div class="row">
       <div class="col-md-6 center-block col-sm-11">
-        <a href="http://kinto.readthedocs.org/en/latest/tutorials/index.html" class="btn">
+        <a href="https://kinto.readthedocs.io/en/latest/tutorials/index.html" class="btn">
           Read the tutorial →</a>
       </div>
     </div>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.